### PR TITLE
Add text to the about me section.

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -32,15 +32,21 @@
         </div>
         </div>
     </div>
-    <section id="about-me">
+    <div="container-fluid" id="about">
+            <h1 class="about-title">About Me</h1>
+            <div class="about-text"><center>
+                <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                    Imperdiet nulla malesuada pellentesque elit eget. Pretium aenean pharetra magna ac placerat vestibulum lectus. Pellentesque 
+                    elit eget gravida cum sociis. Lacus vestibulum sed arcu non odio euismod lacinia at. Auctor eu augue ut lectus arcu bibendum at. 
+                    Sed cras ornare arcu dui vivamus arcu felis bibendum ut. Id eu nisl nunc mi ipsum faucibus vitae. Vel eros donec ac odio tempor 
+                    orci dapibus ultrices in. Nunc sed blandit libero volutpat sed. Elementum nibh tellus molestie nunc non blandit massa. Pellentesque 
+                    habitant morbi tristique senectus et netus et malesuada fames.            
+                </span>
+            </div>
+    </div>
+    <section id="about-carousel">
         <div class="container">
-        <h1 id="about-title"><center> About Me</h1>
-            <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
-                <ol class="carousel-indicators">
-                    <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
-                    <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
-                    <li data-target="#carouselExampleIndicators" data-slide-to="2"></li>
-                </ol>
+            <div id="carouselIndicators" class="carousel slide" data-ride="carousel">
                 <div class="carousel-inner"width="100" height="100">
                     <div class="carousel-item active" >
                     <img class="d-block w-100" src="images/slide1.jpg" alt="First slide" >
@@ -58,16 +64,19 @@
                     <img class="d-block w-100" src="images/slide5.jpg" alt="Third slide">
                     </div>
                 </div>
-                <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+                <a class="carousel-control-prev" href="#carouselIndicators" role="button" data-slide="prev">
                     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                     <span class="sr-only">Previous</span>
                 </a>
-                <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+                <a class="carousel-control-next" href="#carouselIndicators" role="button" data-slide="next">
                     <span class="carousel-control-next-icon" aria-hidden="true"></span>
                     <span class="sr-only">Next</span>
                 </a>
             </div>
         </div>
+    </section>
+    <section id="projects">
+        <h1>Projects Section!</h1>
     </section>
     <!--<div id="content">
       <h1>My Portfolio</h1>

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -39,19 +39,35 @@ body,html {
     color: white; 
 }
 
-#about-me { 
-    height: 800px;
-    color: #3369e8; 
+.about-title {
+    color:#3369e8; 
+    margin-left: 350px;  
+    margin-right: auto; 
+}
+.about-text { 
+    color: #3369e8;  
+    margin-left: 300px;
+    margin-right: 300px;  
+}
+
+#about-carousel { 
+    height: 600px; 
 }
 
 .carousel.slide {
-    position: absolute;
-    width: 500px;
-    height: 500px; 
-    margin-left: 25px;  
-    margin-top: 150px;
+    position: relative;
+    width: 600px;
+    height: 600px; 
+    margin-left: auto; 
+    margin-right: auto; 
+    margin-top: 50px;
+    margin-bottom: -200px; 
 }
 
+#projects {
+    height: 400px; 
+    background-color: #ebeef2; 
+}
 #content {
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
Currently, there was no text displayed in the about me section. This change displays text in the about me section, which is displayed on top of the picture slideshow. The about me layout also has a responsive layout.  

Full Window 
![image](https://user-images.githubusercontent.com/41876222/83253916-d122f580-a17b-11ea-94b6-6daec7cc5be1.png)

Smaller Window 
![image](https://user-images.githubusercontent.com/41876222/83254239-776efb00-a17c-11ea-8cc2-3b85dd14f637.png)
