### PR TITLE
Add contact information with url links.

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -19,7 +19,6 @@
                 <a class="nav-item nav-link" href="#about">About Me</a>
                 <a class="nav-item nav-link" href="#projects">Projects</a>
                 <a class="nav-item nav-link" href="#interests">Interests</a>  
-                <a class="nav-item nav-link" href="#skills">Skills</a>  
                 <a class="nav-item nav-link" href="#contact">Contact Me</a>  
             </div>
         </div>
@@ -100,7 +99,7 @@
                                 Imperdiet nulla malesuada pellentesque elit eget. Pretium aenean pharetra magna ac placerat vestibulum lectus. Pellentesque 
                                 elit eget gravida cum sociis. Lacus vestibulum sed arcu non odio euismod lacinia at. Auctor eu augue ut lectus arcu bibendum at.  
                         </hs2>
-                        <a href="https://github.com/kpatterson01/CapitalOne-Web-Application" class="btn">See GitHub</a>
+                        <a href="https://github.com/kpatterson01/CapitalOne-Web-Application" class="btn btn-danger">See GitHub</a>
                     </div>
                     <img src="images/capital-one-website.jpg" alt="Capital One Website" width=300 height=250>
                 </section>
@@ -121,7 +120,7 @@
                                 Imperdiet nulla malesuada pellentesque elit eget. Pretium aenean pharetra magna ac placerat vestibulum lectus. Pellentesque 
                                 elit eget gravida cum sociis. Lacus vestibulum sed arcu non odio euismod lacinia at. Auctor eu augue ut lectus arcu bibendum at.  
                         </hs2>
-                        <a href="http://frc2590.org/members/kayla-patterson/" class="btn">Nemesis 2590</a>
+                        <a href="http://frc2590.org/members/kayla-patterson/" class="btn btn-danger">Nemesis 2590</a>
                     </div>
                     <img src="images/nao-robot.jpg" alt="Nao Robot" width=300 height=250>
                 </section>
@@ -144,8 +143,22 @@
             </div>
         </div>
     </section> 
+    <section id="contact">
+        <div id="contact-title">
+            <h1>Contact Me</h1>
+            <p>Thank you for visiting my website! Please feel free to connect with me, I am always looking for 
+                mentors, mentees, and people to network with.
+            </p>
+        </div>
+        <div class="container-fluid" id="buttons">
+            <a href="mailto:klypat00@gmail.com" class="btn btn-primary btn-lg">Email Me</a>
+            <a href="https://www.linkedin.com/in/kayla-patterson" class="btn btn-danger btn-lg">LinkedIn</a>
+            <a href="https://github.com/kpatterson01" class="btn btn-success btn-lg">Github</a>
+            <a href="https://drive.google.com/file/d/1HNqcNQGFQX4nzZWO-FFKlE-xT8NCLx03/view?usp=sharing" class="btn btn-warning btn-lg">Resume</a>
+        </div>
+    </section>
     <footer>
-            <p>Website created by Kayla L. Patterson</p>
+        <p>Website created by Kayla L. Patterson</p>
     </footer>
 
     

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -150,6 +150,24 @@ body,html {
   }
 }
 
+#contact {
+    background-color: black;  
+    height: 500px;  
+    padding-top: 20px; 
+}
+
+#contact-title {
+    color: #eeb211; 
+    text-align: center; 
+    margin-top: 50px; 
+}
+
+#buttons { 
+    margin-top: 100px; 
+    text-align: center;
+    align-content: center; 
+}
+
 footer {
     position: static;
     left: 0;
@@ -159,4 +177,4 @@ footer {
     background-color: black;
     color: white;
     text-align: center;
- }
+}


### PR DESCRIPTION
Currently, there was no contact section that displayed my email, GitHub, LinkedIn, or even a resume. This modification displays buttons where a user can click on one of these categories and then it will take them directly to the link. 

![image](https://user-images.githubusercontent.com/41876222/83442733-a7d1c600-a416-11ea-9af6-d072934766c6.png)
